### PR TITLE
Fix null source bytes

### DIFF
--- a/src/main/java/org/opensearch/remoteprocessor/processors/ProtoTranslationUtils.java
+++ b/src/main/java/org/opensearch/remoteprocessor/processors/ProtoTranslationUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -291,7 +292,7 @@ public class ProtoTranslationUtils {
             .setVersion(hit.getVersion())
             .setSeqNo(hit.getSeqNo())
             .setPrimaryTerm(hit.getPrimaryTerm())
-            .setSource(ByteString.copyFrom(hit.getSourceRef().toBytesRef().bytes))
+            .setSource(ByteString.copyFrom(hit.getSourceAsString(), Charset.defaultCharset()))
             .putAllDocumentFields(newDocFields)
             .putAllMetaFields(newMetaFields)
             .putAllHighlightFields(newHighlightFields)


### PR DESCRIPTION
resolves [#3](https://github.com/aryn-ai/remote-processor-service/issues/3).
essentially, I think it's some Lucene thing with extra buffers or something. idk. But this should allow to drop the regex thingy you wrote - now we're sending (hopefully) well-formed json